### PR TITLE
Fix 500 error by lack of the `code' param

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -119,7 +119,7 @@ WeAppStrategy.prototype.authenticate = function(req, options) {
         return self.error(err);
       });
   } else {
-    self.fail("缺少 code", 401);
+    self.fail(401);
   }
 };
 


### PR DESCRIPTION
The [passport](https://github.com/jaredhanson/passport/blob/master/lib/middleware/authenticate.js#L169) package uses as value of `WWW-Authenticate` header the `challenge` argument of [Strategry#fail(challenge, status)](https://github.com/jaredhanson/passport/blob/1fd591d5cdcf6516d9eb446216843223c0e020c4/lib/middleware/authenticate.js#L293), in which it's not recommended to use NON-US-ASCII characters.

According to the IANA maintained [Hypertext Transfer Protocol (HTTP) Authentication Scheme Registry](https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml), there is no auth scheme suited for this procedure of Weapp `code2Session`.

It's best to invoke the `Strategy#fail` with only param `status`, so can `passport` pass over setting the `WWW-Authenticate` header.